### PR TITLE
Test enhancement

### DIFF
--- a/src/CopyObjectAttributesValues.php
+++ b/src/CopyObjectAttributesValues.php
@@ -23,7 +23,7 @@ class CopyObjectAttributesValues
     {
         if (! is_object($toObject)) {
             throw new \RuntimeException(
-                sprintf('Parameter to "%s::to" must be an object, "%s" given', gettype($toObject), static::class)
+                sprintf('Parameter to "%s::to" must be an object, "%s" given', gettype($toObject), __CLASS__)
             );
         }
 
@@ -48,7 +48,7 @@ class CopyObjectAttributesValues
     {
         if (! is_object($fromObject)) {
             throw new \RuntimeException(
-                sprintf('Parameter to "%s::from" must be an object, "%s" given', gettype($fromObject), static::class)
+                sprintf('Parameter to "%s::from" must be an object, "%s" given', gettype($fromObject), __CLASS__)
             );
         }
 

--- a/test/unit/CopyObjectAttributesValuesTest.php
+++ b/test/unit/CopyObjectAttributesValuesTest.php
@@ -31,22 +31,24 @@ class CopyObjectAttributesValuesTest extends TestCase
         $this->assertNotEquals($fromObject->attrCantBeChangedA(), $toObject->attrCantBeChangedB());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testCopyFromInvalidParameter() : void
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf('Parameter to "string::from" must be an object, "%s" given', CopyObjectAttributesValues::class));
+
         CopyObjectAttributesValues::from('test');
     }
 
     /**
      * @dataProvider objectsToBeCopiedProvider
-     * @expectedException \RuntimeException
      *
      * @param ClassForAttributesATest $fromObject
      */
     public function testCopyToInvalidParameter(ClassForAttributesATest $fromObject) : void
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf('Parameter to "string::to" must be an object, "%s" given', CopyObjectAttributesValues::class));
+
         CopyObjectAttributesValues::from($fromObject)->to('test');
     }
 


### PR DESCRIPTION
# Changed log
- Using the `__CLASS__` to get this class instance name is easier than using `static::class`.
- Since the `PHPUni 8.x` version is released, the `expect` Exception annotation is deprecated.

The detailed reference is available [here](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-8.0.md#deprecated).